### PR TITLE
Fix: /set Exchange & RoutingKey from queue name

### DIFF
--- a/redis_broker.go
+++ b/redis_broker.go
@@ -46,6 +46,9 @@ func NewRedisCeleryBroker(uri string, queue string) *RedisCeleryBroker {
 
 // SendCeleryMessage sends CeleryMessage to redis queue
 func (cb *RedisCeleryBroker) SendCeleryMessage(message *CeleryMessage) error {
+	message.Properties.DeliveryInfo.Exchange = cb.queueName
+	message.Properties.DeliveryInfo.RoutingKey = cb.queueName
+
 	jsonBytes, err := json.Marshal(message)
 	if err != nil {
 		return err


### PR DESCRIPTION
So celery messages gets sent with hard coded RougingKey and Exchange (to celery). 
This seems to cause the missing kombu binding key in redis

Investigation in redis shows that the kombu routing keys are formatted like so `_kombu.binding.{queueName}`

```
root@redis-f9f978654-r6bt9:/data# redis-cli keys "*" | grep _kombu
_kombu.binding.automatic
_kombu.binding.celeryev
_kombu.binding.celery.pidbox
_kombu.binding.statistics
_kombu.binding.userflow
_kombu.binding.realtime
```
